### PR TITLE
Altera o href usado para obter as transações

### DIFF
--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -36,7 +36,7 @@ class Nubank:
 
         data = json.loads(request.content.decode('utf-8'))
         self.headers['Authorization'] = 'Bearer {}'.format(data['access_token'])
-        self.feed_url = data['_links']['purchases']['href']
+        self.feed_url = data['_links']['events']['href']
 
     def get_account_statements(self):
         request = requests.get(self.feed_url, headers=self.headers)


### PR DESCRIPTION
Primeiramente parabéns pelo projeto.

Esse pull request altera o href usado para obter as transações. Usando o `purchases` como está atualmente o _response_ vem com muita informação e a requisição é bem mais lenta. Nos meus testes demorou em média 35s usando `purchases` e 0,5s usando `events` como proposto no pull request.

A biblioteca em que foi baseado o projeto [usa](https://github.com/Astrocoders/nubank-api/blob/develop/dist/index.js#L66) o `events`.