### PR TITLE
Melhoria na mensagem de retorno HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ print(sum([t['amount'] for t in card_statements]))
 # Lista de dicionários contendo todas as faturas do seu cartão de crédito
 bills = nu.get_bills()
 
-# Retorna um dicionário contendo os detalhes de uma fatura retornada por
-get_bills()
+# Retorna um dicionário contendo os detalhes de uma fatura retornada por get_bills()
 bill_details = nu.get_bill_details(bills[1])
 ```
 
@@ -47,7 +46,7 @@ nu = Nubank('123456789', 'senha')
 account_statements = nu.get_account_statements()
 
 # Soma de todas as transações na NuConta
-# Observacão: As transações de saída não possuem o valor negativo, então deve-se olhar a propiedade "__typename".
+# Observacão: As transações de saída não possuem o valor negativo, então deve-se olhar a propriedade "__typename".
 # TransferInEvent = Entrada
 # TransferOutEvent = Saída
 print(sum([t['amount'] for t in account_statements]))

--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -48,7 +48,8 @@ class Nubank:
         }
         request = requests.post(Nubank.TOKEN_URL, json=body, headers=self.headers)
         if request.status_code != 200:
-            raise NuException('Authentication failed. {} ({})'.format(json.loads(request.content)['error'], request.status_code))
+            message = '{} ({})'.format(json.loads(request.content)['error'], request.status_code)
+            raise NuException('Authentication failed. {}'.format(message))
 
         data = json.loads(request.content.decode('utf-8'))
         self.headers['Authorization'] = 'Bearer {}'.format(data['access_token'])

--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -48,10 +48,7 @@ class Nubank:
         }
         request = requests.post(Nubank.TOKEN_URL, json=body, headers=self.headers)
         if request.status_code != 200:
-            error_message = '{"error": "Error"}'
-            if request.text != '':
-                error_message = request.text
-            raise NuException('Authentication failed. {} ({})'.format(json.loads(error_message)['error'], request.status_code))
+            raise NuException('Authentication failed. {} ({})'.format(json.loads(request.content)['error'], request.status_code))
 
         data = json.loads(request.content.decode('utf-8'))
         self.headers['Authorization'] = 'Bearer {}'.format(data['access_token'])

--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -48,7 +48,10 @@ class Nubank:
         }
         request = requests.post(Nubank.TOKEN_URL, json=body, headers=self.headers)
         if request.status_code != 200:
-            raise NuException('Authentication failed. {} ({})'.format(json.loads(request.text)['error'], request.status_code))
+            error_message = '{"error": "Error"}'
+            if request.text != '':
+                error_message = request.text
+            raise NuException('Authentication failed. {} ({})'.format(json.loads(error_message)['error'], request.status_code))
 
         data = json.loads(request.content.decode('utf-8'))
         self.headers['Authorization'] = 'Bearer {}'.format(data['access_token'])

--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -48,7 +48,7 @@ class Nubank:
         }
         request = requests.post(Nubank.TOKEN_URL, json=body, headers=self.headers)
         if request.status_code != 200:
-            raise NuException('Authentication failed. Check your credentials!')
+            raise NuException('Authentication failed. {} ({})'.format(json.loads(request.text)['error'], request.status_code))
 
         data = json.loads(request.content.decode('utf-8'))
         self.headers['Authorization'] = 'Bearer {}'.format(data['access_token'])

--- a/tests/test_nubank_client.py
+++ b/tests/test_nubank_client.py
@@ -358,6 +358,7 @@ def create_fake_response(dict_response, status_code=200):
 def test_authentication_failure_raise_exception(monkeypatch, http_status):
     response = Response()
     response.status_code = http_status
+    response._content = b'{"error":"Error"}'
 
     monkeypatch.setattr('requests.post', MagicMock(return_value=response))
     with pytest.raises(NuException):
@@ -587,6 +588,7 @@ def test_grapql_query_raises_exeption(monkeypatch, authentication_return, http_s
 
     response = Response()
     response.status_code = http_status
+    response._content = b'{"error":"Error"}'
 
     monkeypatch.setattr('requests.post', MagicMock(return_value=response))
     with pytest.raises(NuException):


### PR DESCRIPTION
Quando o login for falho, mostrar a mensagem e o código do status do erro. Por exemplo: Too many requests (429) ou Unauthorized (401) e correções no README.