### PR TITLE
Erro quando NuBank solicita token de autenticação no acesso

### DIFF
--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -63,7 +63,9 @@ class Nubank:
 
         data = json.loads(request.content.decode('utf-8'))
         self.headers['Authorization'] = 'Bearer {}'.format(data['access_token'])
-        self.feed_url = data['_links']['events']['href']
+        self.feed_url = data.get('_links', {}).get('events', {}).get('href')
+        if self.feed_url is None:
+            raise NuException('Authentication failed. Invalid feed_url returned')
         self.query_url = data['_links']['ghostflame']['href']
         self.bills_url = data['_links']['bills_summary']['href']
 

--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -65,7 +65,7 @@ class Nubank:
         self.headers['Authorization'] = 'Bearer {}'.format(data['access_token'])
         self.feed_url = data.get('_links', {}).get('events', {}).get('href')
         if self.feed_url is None:
-            raise NuException('Authentication failed. Invalid feed_url returned')
+            raise NuException('Authentication failed. Login using NuBank website, make all steps of authentication and try again.')
         self.query_url = data['_links']['ghostflame']['href']
         self.bills_url = data['_links']['bills_summary']['href']
 

--- a/tests/test_nubank_client.py
+++ b/tests/test_nubank_client.py
@@ -399,6 +399,27 @@ def test_authentication_succeeds(monkeypatch, authentication_return):
     assert nubank_client.headers['Authorization'] == 'Bearer access_token_123'
 
 
+@pytest.mark.parametrize("token_needed_authentication_return",
+                         [
+                             {'access_token': 'ACCESS_TOKEN', 'token_type': 'bearer',
+                              '_links': {'account_emergency': {
+                                  'href': 'https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/XXX'},
+                                  'bill_emergency': {
+                                      'href': 'https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/XXX'},
+                                  'revoke_token': {
+                                      'href': 'https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/XXX'},
+                                  'revoke_all': {
+                                      'href': 'https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/XXX'}},
+                              'refresh_token': 'token',
+                              'refresh_before': '2018-12-24T09:50:02Z'}
+                         ])
+def test_authentication_failed_token_needed(monkeypatch, token_needed_authentication_return):
+    response = create_fake_response(token_needed_authentication_return)
+    monkeypatch.setattr('requests.post', MagicMock(return_value=response))
+    with pytest.raises(NuException):
+        Nubank('12345678909', '12345678')
+
+
 def test_get_card_feed(monkeypatch, authentication_return, events_return):
     response = create_fake_response(authentication_return)
     monkeypatch.setattr('requests.post', MagicMock(return_value=response))


### PR DESCRIPTION
Conforme detalhado na issue #27 este pull request dispara um NuException quando o Nubank retorna dados sem o feed_url.