### PR TITLE
NuException had empty message due to exception message not being passed to super init

### DIFF
--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -18,7 +18,6 @@ PAYMENT_EVENT_TYPES = (
 
 
 class NuException(Exception):
-
     def __init__(self, status_code, response, url):
         super().__init__(f'The request made failed with HTTP status code {status_code}')
         self.url = url
@@ -81,7 +80,7 @@ class Nubank:
 
     def _handle_response(self, response: Response) -> dict:
         if response.status_code != 200:
-            raise NuException(response.status_code, response.status_code, response.json())
+            raise NuException(response.status_code, response.json(), response.url)
 
         return response.json()
 

--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -20,7 +20,7 @@ PAYMENT_EVENT_TYPES = (
 class NuException(Exception):
 
     def __init__(self, status_code, response, url):
-        super().__init__()
+        super().__init__(f'The request made failed with HTTP status code {status_code}')
         self.url = url
         self.status_code = status_code
         self.response = response
@@ -81,8 +81,7 @@ class Nubank:
 
     def _handle_response(self, response: Response) -> dict:
         if response.status_code != 200:
-            raise NuException(f'The request made failed with HTTP status code {response.status_code}',
-                              response.status_code, response.json())
+            raise NuException(response.status_code, response.status_code, response.json())
 
         return response.json()
 

--- a/tests/test_nubank_client.py
+++ b/tests/test_nubank_client.py
@@ -683,6 +683,7 @@ def test_get_qr_code():
     assert uid != ''
     assert isinstance(qr, QRCode)
 
+
 not_accepted_http_codes = [
     100, 101, 102, 103,
     201, 202, 203, 204, 205, 206, 207, 208, 226,
@@ -693,7 +694,8 @@ not_accepted_http_codes = [
     500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 520, 521, 522, 523, 524, 525, 526, 527, 530, 598
 ]
 
-@pytest.mark.parametrize("http_status", not_accepted_http_codes)
+
+@pytest.mark.parametrize('http_status', not_accepted_http_codes)
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
 def test_nubank_request_handler_throws_exception_on_status_different_of_200(http_status):
     response = create_fake_response({}, http_status)
@@ -701,7 +703,8 @@ def test_nubank_request_handler_throws_exception_on_status_different_of_200(http
     with pytest.raises(NuException):
         client._handle_response(response)
 
-@pytest.mark.parametrize("http_status", not_accepted_http_codes)
+
+@pytest.mark.parametrize('http_status', not_accepted_http_codes)
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
 def test_nubank_request_handler_throws_exception_with_status_code_attribute(http_status):
     response = create_fake_response({}, http_status)
@@ -711,13 +714,15 @@ def test_nubank_request_handler_throws_exception_with_status_code_attribute(http
 
     assert exception_info.value.status_code == http_status
 
-@pytest.mark.parametrize("http_status", not_accepted_http_codes)
+
+@pytest.mark.parametrize('http_status', not_accepted_http_codes)
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
 def test_nubank_request_handler_throws_exception_status_code_in_the_exception_message(http_status):
     response = create_fake_response({}, http_status)
     client = Nubank()
-    with pytest.raises(NuException, match=fr".*{http_status}.*"):
+    with pytest.raises(NuException, match=fr'.*{http_status}.*'):
         client._handle_response(response)
+
 
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
 def test_nubank_request_handler_throws_exception_with_url_attribute():
@@ -727,6 +732,7 @@ def test_nubank_request_handler_throws_exception_with_url_attribute():
         client._handle_response(response)
 
     assert exception_info.value.url == response.url
+
 
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
 def test_nubank_request_handler_throws_exception_with_response_attribute():

--- a/tests/test_nubank_client.py
+++ b/tests/test_nubank_client.py
@@ -684,7 +684,7 @@ def test_get_qr_code():
     assert isinstance(qr, QRCode)
 
 
-not_accepted_http_codes = [
+@pytest.mark.parametrize('http_status', [
     100, 101, 102, 103,
     201, 202, 203, 204, 205, 206, 207, 208, 226,
     300, 301, 302, 303, 304, 305, 306, 307, 308,
@@ -692,10 +692,7 @@ not_accepted_http_codes = [
     423,
     424, 426, 428, 429, 431, 440, 444, 449, 450, 451, 495, 496, 497, 498, 499,
     500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 520, 521, 522, 523, 524, 525, 526, 527, 530, 598
-]
-
-
-@pytest.mark.parametrize('http_status', not_accepted_http_codes)
+])
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
 def test_nubank_request_handler_throws_exception_on_status_different_of_200(http_status):
     response = create_fake_response({}, http_status)
@@ -704,9 +701,9 @@ def test_nubank_request_handler_throws_exception_on_status_different_of_200(http
         client._handle_response(response)
 
 
-@pytest.mark.parametrize('http_status', not_accepted_http_codes)
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
-def test_nubank_request_handler_throws_exception_with_status_code_attribute(http_status):
+def test_nubank_request_handler_throws_exception_with_status_code_attribute():
+    http_status = 400
     response = create_fake_response({}, http_status)
     client = Nubank()
     with pytest.raises(NuException) as exception_info:
@@ -715,9 +712,9 @@ def test_nubank_request_handler_throws_exception_with_status_code_attribute(http
     assert exception_info.value.status_code == http_status
 
 
-@pytest.mark.parametrize('http_status', not_accepted_http_codes)
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
-def test_nubank_request_handler_throws_exception_status_code_in_the_exception_message(http_status):
+def test_nubank_request_handler_throws_exception_status_code_in_the_exception_message():
+    http_status = 400
     response = create_fake_response({}, http_status)
     client = Nubank()
     with pytest.raises(NuException, match=fr'.*{http_status}.*'):

--- a/tests/test_nubank_client.py
+++ b/tests/test_nubank_client.py
@@ -683,8 +683,7 @@ def test_get_qr_code():
     assert uid != ''
     assert isinstance(qr, QRCode)
 
-
-@pytest.mark.parametrize("http_status", [
+not_accepted_http_codes = [
     100, 101, 102, 103,
     201, 202, 203, 204, 205, 206, 207, 208, 226,
     300, 301, 302, 303, 304, 305, 306, 307, 308,
@@ -692,10 +691,48 @@ def test_get_qr_code():
     423,
     424, 426, 428, 429, 431, 440, 444, 449, 450, 451, 495, 496, 497, 498, 499,
     500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 520, 521, 522, 523, 524, 525, 526, 527, 530, 598
-])
+]
+
+@pytest.mark.parametrize("http_status", not_accepted_http_codes)
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
 def test_nubank_request_handler_throws_exception_on_status_different_of_200(http_status):
     response = create_fake_response({}, http_status)
     client = Nubank()
     with pytest.raises(NuException):
         client._handle_response(response)
+
+@pytest.mark.parametrize("http_status", not_accepted_http_codes)
+@patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
+def test_nubank_request_handler_throws_exception_with_status_code_attribute(http_status):
+    response = create_fake_response({}, http_status)
+    client = Nubank()
+    with pytest.raises(NuException) as exception_info:
+        client._handle_response(response)
+
+    assert exception_info.value.status_code == http_status
+
+@pytest.mark.parametrize("http_status", not_accepted_http_codes)
+@patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
+def test_nubank_request_handler_throws_exception_status_code_in_the_exception_message(http_status):
+    response = create_fake_response({}, http_status)
+    client = Nubank()
+    with pytest.raises(NuException, match=fr".*{http_status}.*"):
+        client._handle_response(response)
+
+@patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
+def test_nubank_request_handler_throws_exception_with_url_attribute():
+    response = create_fake_response({}, 400)
+    client = Nubank()
+    with pytest.raises(NuException) as exception_info:
+        client._handle_response(response)
+
+    assert exception_info.value.url == response.url
+
+@patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)
+def test_nubank_request_handler_throws_exception_with_response_attribute():
+    response = create_fake_response({}, 400)
+    client = Nubank()
+    with pytest.raises(NuException) as exception_info:
+        client._handle_response(response)
+
+    assert exception_info.value.response == response.json()


### PR DESCRIPTION
The NuException was expecting a status_code as the first argument but had a error message instead.

The message was not passed to the super().__init__() this caused the exception to be Empty ("NuException: ")

The raise of the exception was fixed so it passes the correct arguments.
The error message creation was moved inside of the NuException __init__ and passed to the super __init__.

Closes #80 