### PR TITLE
Added an is_authenticated method to the Nubank class

### DIFF
--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -134,3 +134,6 @@ class Nubank:
     def get_account_balance(self):
         data = self._make_graphql_request('account_balance')
         return data['data']['viewer']['savingsAccount']['currentSavingsBalance']['netAmount']
+
+    def is_authenticated(self):
+        return 'Authorization' in self.headers.keys()

--- a/tests/test_nubank_client.py
+++ b/tests/test_nubank_client.py
@@ -409,7 +409,7 @@ def test_authenticate_with_qr_code_succeeds(monkeypatch, authentication_return, 
 
     assert nubank_client.feed_url == 'https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/events_123'
     assert nubank_client.headers['Authorization'] == 'Bearer access_token_123'
-    assert nubank_client.is_authenticated == True
+    assert nubank_client.is_authenticated() == True
 
 
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)

--- a/tests/test_nubank_client.py
+++ b/tests/test_nubank_client.py
@@ -409,6 +409,7 @@ def test_authenticate_with_qr_code_succeeds(monkeypatch, authentication_return, 
 
     assert nubank_client.feed_url == 'https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/events_123'
     assert nubank_client.headers['Authorization'] == 'Bearer access_token_123'
+    assert nubank_client.is_authenticated == True
 
 
 @patch.object(Nubank, '_update_proxy_urls', fake_update_proxy)


### PR DESCRIPTION
The nubank API has been giving lots of 404's while trying to login, even on it's web app, as the image shows:
![grafik](https://user-images.githubusercontent.com/14372822/76982773-1d9bba80-691b-11ea-93d8-6b75bd6de244.png)

To guarantee we're successfully logged and avoid ugly loops, I added a simple "is_authenticated()" function to the Nubank class. It simply checks if the 'Authorization' header is present.

I understand it can lead to wrong results if the token ever expire and this is now a point of improvement which I plan to work on.

With this new method, the login loop should look like this:

```
while not nu.is_authenticated()

    try:

        nu.authenticate_with_qr_code("cpf", "password", uuid)

    except Exception as e:

        print( e )
```