### PR TITLE
Add random code to the device name

### DIFF
--- a/pynubank/utils/certificate_generator.py
+++ b/pynubank/utils/certificate_generator.py
@@ -56,7 +56,7 @@ class CertificateGenerator:
             'password': self.password,
             'public_key': self._get_public_key(self.key1),
             'public_key_crypto': self._get_public_key(self.key2),
-            'model': 'PyNubank Client',
+            'model': f'PyNubank Client ({self.device_id})',
             'device_id': self.device_id
         }
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pynubank',
-    version='2.6.0',
+    version='2.6.1',
     url='https://github.com/andreroggeri/pynubank',
     author='André Roggeri Campos',
     author_email='a.roggeri.c@gmail.com',


### PR DESCRIPTION
Some users reported that they cannot login into multiple accounts on the same machine. This may help with that problem