### PR TITLE
feat:  Add payment_code in create_pix_payment_qrcode

### DIFF
--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -240,5 +240,6 @@ class Nubank:
 
         return {
             'payment_url': data['url'],
-            'qr_code': qr
+            'payment_code': data['brcode'],
+            'qr_code': qr,
         }

--- a/tests/test_nubank_client.py
+++ b/tests/test_nubank_client.py
@@ -372,6 +372,8 @@ def test_should_create_pix_money_request():
     request = nubank_client.create_pix_payment_qrcode('1231231232', 1232213.23, keys_data['keys'][0])
 
     assert request['qr_code'] is not None
+    assert request['payment_code'] == '12464565442165BR.GOV.BCB.PIX42136542416542146542165.005802BR5920John ' \
+                                      'Doe6009SAO PAULOSf5ASF56sf654aA65sa4f6S56fs'
     assert request['payment_url'] == 'https://nubank.com.br/pagar/tttttt/yyyyyyy'
 
 


### PR DESCRIPTION
Foi adicionado o código do Pix "Copia e Cola" como retorno ao método create_pix_payment_qrcode, e adicionado um teste que validasse o retorno.