### PR TITLE
Nova categoria de pagamento e parsing de transações pix(pix agendado)

### DIFF
--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -27,6 +27,7 @@ PAYMENT_EVENT_TYPES = (
     'PixTransferInEvent',
     'PixTransferOutReversalEvent',
     'PixTransferFailedEvent',
+    'PixTransferScheduledEvent',
 )
 
 

--- a/pynubank/utils/parsing.py
+++ b/pynubank/utils/parsing.py
@@ -4,12 +4,14 @@ TITLE_INFLOW_PIX = 'Transferência recebida'
 TITLE_OUTFLOW_PIX = 'Transferência enviada'
 TITLE_REVERSAL_PIX = 'Reembolso enviado'
 TITLE_FAILED_PIX = 'Transferência falhou'
+TITLE_SCHEDULED_PIX = 'Transferência agendada'
 
 PIX_TRANSACTION_MAP = {
     TITLE_INFLOW_PIX: 'PixTransferInEvent',
     TITLE_OUTFLOW_PIX: 'PixTransferOutEvent',
     TITLE_REVERSAL_PIX: 'PixTransferOutReversalEvent',
     TITLE_FAILED_PIX: 'PixTransferFailedEvent',
+    TITLE_SCHEDULED_PIX: 'PixTransferScheduledEvent',
 }
 
 


### PR DESCRIPTION
Agora é possível fazer agendamento de transferências via pix.

`{'id': 'xxxx',
  '__typename': 'GenericFeedEvent',
  'title': 'Transferência agendada',
  'detail': 'EQUATORIAL ALAGOAS DISTRIBUIDORA DE ENERGIA S.A.',
  'postDate': '2021-12-22'}`