### PR TITLE
fix: Don't fail parsing pix transactions without value

### DIFF
--- a/pynubank/utils/parsing.py
+++ b/pynubank/utils/parsing.py
@@ -1,5 +1,6 @@
 import re
 
+BRL = 'R$'
 TITLE_INFLOW_PIX = 'Transferência recebida'
 TITLE_OUTFLOW_PIX = 'Transferência enviada'
 TITLE_REVERSAL_PIX = 'Reembolso enviado'
@@ -23,7 +24,7 @@ def parse_pix_transaction(transaction: dict) -> dict:
     if transaction['__typename'] != 'GenericFeedEvent':
         return transaction
 
-    if transaction['title'] in PIX_TRANSACTION_MAP.keys():
+    if BRL in transaction['detail'] and transaction['title'] in PIX_TRANSACTION_MAP.keys():
         transaction['__typename'] = PIX_TRANSACTION_MAP[transaction['title']]
         transaction['amount'] = parse_float(transaction['detail'])
 
@@ -32,9 +33,9 @@ def parse_pix_transaction(transaction: dict) -> dict:
 
 def parse_generic_transaction(transaction: dict) -> dict:
     amount = None
-    if transaction['node']['detail'] and 'R$' in transaction['node']['detail']:
+    if transaction['node']['detail'] and BRL in transaction['node']['detail']:
         amount = parse_float(transaction['node']['detail'])
-    elif transaction['node']['footer'] and 'R$' in transaction['node']['footer']:
+    elif transaction['node']['footer'] and BRL in transaction['node']['footer']:
         amount = parse_float(transaction['node']['footer'])
 
     if amount:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -71,6 +71,17 @@ def test_should_parse_failed_pix_transaction():
     assert parsed['amount'] == 3668.40
 
 
+def test_should_ignore_transactions_without_value():
+    transaction = base_generic_transaction.copy()
+    transaction['title'] = 'Transferência enviada'
+    transaction['detail'] = 'Something without money'
+
+    parsed = parse_pix_transaction(transaction)
+
+    assert parsed['__typename'] == 'GenericFeedEvent'
+    assert parsed.get('amount') is None
+
+
 def test_parse_generic_transaction_should_retrieve_amount_from_detail_when_contains_rs():
     transaction = create_edge_transaction()
     transaction['node']['detail'] = 'R$ 123,56'


### PR DESCRIPTION
Closes #335 