### PR TITLE
chore: Deprecate account_feed methods in favor of the paginated one

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ qrcode==7.3.1
 pyOpenSSL==22.0.0
 colorama==0.4.3
 requests-pkcs12==1.13
+Deprecated==1.2.13


### PR DESCRIPTION
The API is not returning the feed anymore for some people. In the future we can remove this method.

Closes #341 