### PR TITLE
Parse old transfer after nubank change

### DIFF
--- a/pynubank/nubank.py
+++ b/pynubank/nubank.py
@@ -11,7 +11,7 @@ from pynubank.exception import NuMissingCreditCard
 from pynubank.utils.discovery import Discovery
 from pynubank.utils.graphql import prepare_request_body
 from pynubank.utils.http import HttpClient
-from pynubank.utils.parsing import parse_float, parse_pix_transaction
+from pynubank.utils.parsing import parse_float, parse_transaction
 
 PAYMENT_EVENT_TYPES = (
     'TransferOutEvent',
@@ -184,7 +184,7 @@ class Nubank:
     @requires_auth_mode(AuthMode.APP)
     def get_account_statements(self):
         feed = self.get_account_feed()
-        feed = map(parse_pix_transaction, feed)
+        feed = map(parse_transaction, feed)
         return list(filter(lambda x: x['__typename'] in PAYMENT_EVENT_TYPES, feed))
 
     @requires_auth_mode(AuthMode.APP)

--- a/pynubank/utils/parsing.py
+++ b/pynubank/utils/parsing.py
@@ -5,26 +5,31 @@ TITLE_OUTFLOW_PIX = 'Transferência enviada'
 TITLE_REVERSAL_PIX = 'Reembolso enviado'
 TITLE_FAILED_PIX = 'Transferência falhou'
 TITLE_SCHEDULED_PIX = 'Transferência agendada'
+TITLE_INFLOW_TED_DOC = 'Transferência recebida em processamento'
 
-PIX_TRANSACTION_MAP = {
+TRANSACTION_MAP = {
     TITLE_INFLOW_PIX: 'PixTransferInEvent',
     TITLE_OUTFLOW_PIX: 'PixTransferOutEvent',
     TITLE_REVERSAL_PIX: 'PixTransferOutReversalEvent',
     TITLE_FAILED_PIX: 'PixTransferFailedEvent',
     TITLE_SCHEDULED_PIX: 'PixTransferScheduledEvent',
+    TITLE_INFLOW_TED_DOC: 'TransferInEvent',
 }
 
 
 def parse_float(value: str):
     return float(re.search(r'(?:\d*\.)*\d+,\d{1,2}', value).group().replace('.', '').replace(',', '.'))
 
-
-def parse_pix_transaction(transaction: dict) -> dict:
+def parse_transaction(transaction: dict) -> dict:
     if transaction['__typename'] != 'GenericFeedEvent':
         return transaction
 
-    if transaction['title'] in PIX_TRANSACTION_MAP.keys():
-        transaction['__typename'] = PIX_TRANSACTION_MAP[transaction['title']]
+    if transaction['title'] in TRANSACTION_MAP.keys():
+        transaction['__typename'] = TRANSACTION_MAP[transaction['title']]
         transaction['amount'] = parse_float(transaction['detail'])
+        if "\n" in transaction['detail']:
+            split_details = transaction['detail'].split('\n')
+            transaction['originAccount'] = {"name": split_details[0]}
+            transaction['detail'] = split_details[1]
 
     return transaction


### PR DESCRIPTION
Nubank changed the typename for old transactions from TransferOutEvent to GenericFeedEvent and added a "em processamento" like:

{'id': '[REDACTED]', '__typename': 'GenericFeedEvent', 'title': 'Transferência recebida em processamento', 'detail': '[REDACTED]', 'postDate': '2018-02-05'}

This commit turn the pix parse into a generic parser that translate this generic event into the same format as before.